### PR TITLE
Fix for #11

### DIFF
--- a/hello-world-lambda/Dockerfile
+++ b/hello-world-lambda/Dockerfile
@@ -14,7 +14,7 @@ RUN apk --no-cache add curl \
 
 USER app
 
-ENV fprocess="java -noverify -XX:TieredStopAtLevel=1 -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -jar Handler.jar"
+ENV fprocess="xargs java -noverify -XX:TieredStopAtLevel=1 -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -jar Handler.jar -d"
 
 HEALTHCHECK --interval=1s CMD [ -e /tmp/.lock ] || exit 1
 


### PR DESCRIPTION
This is a fix for issue #11 .

To test.

1. Create a function using the micronaut cli
```
mn create-function foo --features openfaas
```

2. Create a `foo.yml` file outside the function directory with the following contents:
```yml
provider:
  name: faas
  gateway: http://127.0.0.1:8080

functions:
  foo:
    lang: dockerfile
    handler: ./foo
    image: foo
```
3. Compile the function
```
cd foo
gradle build
```

4. Use the faas cli to deploy the function to OpenFaas
```
cd ..
faas build -f ./foo.yml
faas deploy -f ./foo.yml
```

5. Invoke the function
```
faas invoke foo
```