### PR TITLE
Upgraded and introduced global kotlin version

### DIFF
--- a/hello-world-kotlin/build.gradle
+++ b/hello-world-kotlin/build.gradle
@@ -1,4 +1,7 @@
 buildscript {
+    ext {
+        kotlinVersion = '1.3.10'
+    }
     repositories {
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
@@ -6,7 +9,7 @@ buildscript {
     dependencies {
         classpath "com.github.jengelman.gradle.plugins:shadow:2.0.4"
         classpath "io.spring.gradle:dependency-management-plugin:1.0.5.RELEASE"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.2.31"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     }
 }
 
@@ -38,8 +41,8 @@ dependencies {
     compile "io.micronaut:micronaut-http-server-netty"
     compile "io.micronaut:micronaut-inject"
     compile "io.micronaut:micronaut-runtime"
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.31"
-    compile "org.jetbrains.kotlin:kotlin-reflect:1.2.31"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
+    compile "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
     compileOnly "io.micronaut:micronaut-inject-java"
     kapt "io.micronaut:micronaut-inject-java"
     kaptTest "io.micronaut:micronaut-inject-java"
@@ -56,11 +59,7 @@ shadowJar {
     mergeServiceFiles()
 }
 
-run.jvmArgs('-noverify', '-XX:TieredStopAtLevel=1')
-
 mainClassName = "example.Application"
-compileJava.options.compilerArgs += '-parameters'
-compileTestJava.options.compilerArgs += '-parameters'
 
 test {
     useJUnitPlatform()


### PR DESCRIPTION
Updated kotlin version to 1.3.10 and added a global kotlinVersion variable for making the change of the version easier in the future (to not forget the dependencies or the plugin).

Details:
The kotlin version is the problem to run the hello world kotlin example with JDK 10. An update to kotlin 1.3.10 fixes this issue. Also tested with version 1.2.71 and it works as well (but obviously the newest version makes more sense).
