### PR TITLE
Avoid undefined error on vendor.pets in storefront

### DIFF
--- a/petstore/storefront/src/main/resources/static/index.html
+++ b/petstore/storefront/src/main/resources/static/index.html
@@ -132,7 +132,7 @@
         }
 		function vendorHtml(vendor) {
 			var html = "<h2>" + vendor.name + "</h2>";
-			if ( vendor.pets.length == 0 ) {
+			if ( vendor.pets === undefined || vendor.pets.length === 0 ) {
 				html += 'No pets available';	
 			} else {
 				html += petsRow(vendor.pets);


### PR DESCRIPTION
Fixes `Uncaught TypeError: Cannot read property 'length' of undefined` in storefront.