### PR TITLE
updated versions in package.json

### DIFF
--- a/petstore/frontend/react/package.json
+++ b/petstore/frontend/react/package.json
@@ -9,16 +9,16 @@
     "test": "react-scripts test --env=jsdom"
   },
   "dependencies": {
-    "react": "^16.8.2",
-    "react-dom": "^16.8.2",
-    "react-router": "^4.3.1",
-    "react-router-dom": "^4.3.1",
-    "react-scripts": "2.1.5"
+    "react": "^16.8.5",
+    "react-dom": "^16.8.5",
+    "react-router": "^5.0.0",
+    "react-router-dom": "^5.0.0",
+    "react-scripts": "2.1.8"
   },
   "devDependencies": {
-    "babel-eslint": "9.0.0",
-    "eslint": "5.12.0",
-    "eslint-config-prettier": "^4.0.0",
+    "babel-eslint": "10.0.1",
+    "eslint": "5.15.3",
+    "eslint-config-prettier": "^4.1.0",
     "eslint-plugin-html": "^5.0.3",
     "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-jsx-a11y": "^6.2.1",


### PR DESCRIPTION
This addresses some security warnings in npm packages. The only remaining warning is about a "low severity vulnerability" in a package called "braces". This same warning is reported 63 times. Here's a description of the issue:

```text
Version of braces prior to 2.3.1 are vulnerable to Regular Expression Denial of Service (ReDoS). Untrusted input may cause catastrophic backtracking while matching regular expressions. This can cause the application to be unresponsive leading to Denial of Service.
```

The braces package is used by dependencies of the jest package which is used by the react-scripts package. The newest version of jest addresses this, but the newest version of react-scripts doesn't use that yet. When react-scripts is updated we can switch to that version and these warnings should go away.
