### PR TITLE
Wait for 300 seconds instead of 60 seconds for dependencies on Docker container startup

### DIFF
--- a/petstore/comments/Dockerfile
+++ b/petstore/comments/Dockerfile
@@ -1,7 +1,7 @@
 FROM java:openjdk-8u111-alpine
 RUN apk --no-cache add curl
-CMD ./wait-for -t 60 $CONSUL_HOST:$CONSUL_PORT -- \
-    ./wait-for -t 60 $NEO4J_HOST:$NEO4J_PORT -- \
+CMD ./wait-for -t 300 $CONSUL_HOST:$CONSUL_PORT -- \
+        ./wait-for -t 300 $NEO4J_HOST:$NEO4J_PORT -- \
         echo "All dependencies ready. Starting application..." && \
         java ${JAVA_OPTS} -jar comments-all.jar
 COPY build/libs/*-all.jar comments-all.jar

--- a/petstore/mail/Dockerfile
+++ b/petstore/mail/Dockerfile
@@ -1,6 +1,6 @@
 FROM java:openjdk-8u111-alpine
 RUN apk --no-cache add curl
-CMD ./wait-for -t 60 $CONSUL_HOST:$CONSUL_PORT -- \
+CMD ./wait-for -t 300 $CONSUL_HOST:$CONSUL_PORT -- \
     echo "All dependencies ready. Starting application..." && \
     java ${JAVA_OPTS} -jar mail-all.jar
 COPY build/libs/*-all.jar mail-all.jar

--- a/petstore/offers/Dockerfile
+++ b/petstore/offers/Dockerfile
@@ -1,9 +1,9 @@
 FROM java:openjdk-8u111-alpine
 RUN apk --no-cache add curl
-CMD ./wait-for -t 60 $CONSUL_HOST:$CONSUL_PORT -- \
-    ./wait-for -t 60 $REDIS_HOST:$REDIS_PORT -- \
-    ./wait-for -t 60 pets:8080 -- \
-    ./wait-for -t 60 storefront:8080 -- \
+CMD ./wait-for -t 300 $CONSUL_HOST:$CONSUL_PORT -- \
+        ./wait-for -t 300 $REDIS_HOST:$REDIS_PORT -- \
+        ./wait-for -t 300 pets:8080 -- \
+        ./wait-for -t 300 storefront:8080 -- \
         echo "All dependencies ready. Starting application..." && \
         java ${JAVA_OPTS} -jar offers-all.jar
 COPY build/libs/*-all.jar offers-all.jar

--- a/petstore/pets/Dockerfile
+++ b/petstore/pets/Dockerfile
@@ -1,7 +1,7 @@
 FROM java:openjdk-8u111-alpine
 RUN apk --no-cache add curl
-CMD ./wait-for -t 60 $CONSUL_HOST:$CONSUL_PORT -- \
-    ./wait-for -t 60 $MONGO_HOST:$MONGO_PORT -- \
+CMD ./wait-for -t 300 $CONSUL_HOST:$CONSUL_PORT -- \
+        ./wait-for -t 300 $MONGO_HOST:$MONGO_PORT -- \
         echo "All dependencies ready. Starting application..." && \
         java ${JAVA_OPTS} -jar pets-all.jar
 COPY build/libs/*-all.jar pets-all.jar

--- a/petstore/storefront/Dockerfile
+++ b/petstore/storefront/Dockerfile
@@ -1,9 +1,9 @@
 FROM java:openjdk-8u111-alpine
 RUN apk --no-cache add curl
-CMD ./wait-for -t 60 $CONSUL_HOST:$CONSUL_PORT -- \
-    ./wait-for -t 60 pets:8080 -- \
-    ./wait-for -t 60 vendors:8080 -- \
-    ./wait-for -t 60 comments:8080 -- \
+CMD ./wait-for -t 300 $CONSUL_HOST:$CONSUL_PORT -- \
+        ./wait-for -t 300 pets:8080 -- \
+        ./wait-for -t 300 vendors:8080 -- \
+        ./wait-for -t 300 comments:8080 -- \
         echo "All dependencies ready. Starting application..." && \
         java ${JAVA_OPTS} -jar storefront-all.jar
 COPY build/libs/*-all.jar storefront-all.jar

--- a/petstore/vendors/Dockerfile
+++ b/petstore/vendors/Dockerfile
@@ -1,6 +1,6 @@
 FROM java:openjdk-8u111-alpine
 RUN apk --no-cache add curl
-CMD ./wait-for -t 60 $CONSUL_HOST:$CONSUL_PORT -- \
+CMD ./wait-for -t 300 $CONSUL_HOST:$CONSUL_PORT -- \
         echo "All dependencies ready. Starting application..." && \
         java ${JAVA_OPTS} -jar vendors-all.jar
 COPY build/libs/*-all.jar vendors-all.jar


### PR DESCRIPTION
Older machines (or Docker on Windows, which is usually a rather small VM) may fail to start up all services in 60 seconds (especially when they are started the first time and take some more time for initialization). The containers then exit with error. The docker-compose.yml does not specify to restart them, so they remain in their stopped/failed state. 300 seconds should give all containers enough time to start up.