### PR TITLE
Update docker file

### DIFF
--- a/hello-world-java/Dockerfile
+++ b/hello-world-java/Dockerfile
@@ -1,4 +1,4 @@
 FROM adoptopenjdk/openjdk11-openj9:jdk-11.0.1.13-alpine-slim
 COPY build/libs/example-*-all.jar example.jar
 EXPOSE 8080
-CMD java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dcom.sun.management.jmxremote -noverify ${JAVA_OPTS} -jar example.jar
+CMD java -XX:+UnlockExperimentalVMOptions -Dcom.sun.management.jmxremote ${JAVA_OPTS} -jar example.jar


### PR DESCRIPTION
`UseCGroupMemoryLimitForHeap` : is no longer needed on JDK 11
`-noverify` : I have worked on some micronaut project and I have made the observation that many developers dont really understand what disabling `-noverify` means . I do understand that for the sake of this example you have put it intentionally - to speed things up - but unfortunately due to copy paste programming in many cases noverify ends up in production. - which is should not. 

 Thanks for considering

`References` : https://medium.com/@speakjava/jdk-11-pitfalls-for-the-unwary-e08d864065c1