### PR TITLE
websocket-chat upgraded to Micronaut 3.1.3, Gradle wrapper upgraded, Spock unit test added

### DIFF
--- a/websocket-chat/build.gradle
+++ b/websocket-chat/build.gradle
@@ -1,10 +1,7 @@
 plugins {
-    id "io.spring.dependency-management" version "1.0.6.RELEASE"
-    id "java"
-    id "net.ltgt.apt-eclipse" version "0.21"
-    id "net.ltgt.apt-idea" version "0.21"
-    id "com.github.johnrengelman.shadow" version "4.0.2"
-    id "application"
+    id("groovy")
+    id("com.github.johnrengelman.shadow") version "7.1.0"
+    id("io.micronaut.application") version "2.0.8"
 }
 
 version "0.1"
@@ -12,50 +9,34 @@ group "websocket.chat"
 
 repositories {
     mavenCentral()
-    maven { url "https://jcenter.bintray.com" }
 }
 
-dependencyManagement {
-    imports {
-        mavenBom 'io.micronaut:micronaut-bom:1.1.0'
+micronaut {
+    runtime("netty")
+    testRuntime("spock2")
+    processing {
+        incremental(true)
+        annotations("websocket.chat.*")
     }
 }
 
-configurations {
-    // for dependencies that are needed for development only
-    developmentOnly
-}
-
 dependencies {
-    annotationProcessor "io.micronaut:micronaut-inject-java"
-    annotationProcessor "io.micronaut:micronaut-validation"
-    compile "io.micronaut:micronaut-inject"
-    compile "io.micronaut:micronaut-validation"
-    compile "io.micronaut:micronaut-runtime"
-    compile "io.micronaut:micronaut-http-client"
-    compile "io.micronaut:micronaut-http-server-netty"
-    runtime "ch.qos.logback:logback-classic:1.2.3"
-    testAnnotationProcessor "io.micronaut:micronaut-inject-java"
-    testCompile "org.junit.jupiter:junit-jupiter-api"
-    testCompile "io.micronaut.test:micronaut-test-junit5"
-    testRuntime "org.junit.jupiter:junit-jupiter-engine"
+    implementation platform("io.micronaut:micronaut-bom:$micronautVersion")
+
+    annotationProcessor("io.micronaut:micronaut-http-validation")
+    implementation("io.micronaut:micronaut-http-client")
+    implementation("io.micronaut:micronaut-runtime")
+    implementation("javax.annotation:javax.annotation-api")
+    runtimeOnly("ch.qos.logback:logback-classic")
+    implementation("io.micronaut:micronaut-validation")
+
+    testImplementation("io.reactivex.rxjava3:rxjava:3.1.2")
 }
 
-test.classpath += configurations.developmentOnly
-
-mainClassName = "websocket.chat.Application"
-// use JUnit 5 platform
-test {
-    useJUnitPlatform()
+application {
+    mainClass.set("websocket.chat.Application")
 }
-tasks.withType(JavaCompile){
-    options.encoding = "UTF-8"
-    options.compilerArgs.add('-parameters')
+java {
+    sourceCompatibility = JavaVersion.toVersion("8")
+    targetCompatibility = JavaVersion.toVersion("8")
 }
-
-shadowJar {
-    mergeServiceFiles()
-}
-
-run.classpath += configurations.developmentOnly
-run.jvmArgs('-noverify', '-XX:TieredStopAtLevel=1', '-Dcom.sun.management.jmxremote')

--- a/websocket-chat/gradle.properties
+++ b/websocket-chat/gradle.properties
@@ -1,0 +1,1 @@
+micronautVersion=3.1.3

--- a/websocket-chat/gradle/wrapper/gradle-wrapper.properties
+++ b/websocket-chat/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/websocket-chat/settings.gradle
+++ b/websocket-chat/settings.gradle
@@ -1,0 +1,2 @@
+
+rootProject.name="websocket-chat"

--- a/websocket-chat/src/test/groovy/websocket/chat/ChatWebSocketSpec.groovy
+++ b/websocket-chat/src/test/groovy/websocket/chat/ChatWebSocketSpec.groovy
@@ -1,0 +1,133 @@
+package websocket.chat
+
+import groovy.transform.CompileStatic
+import io.micronaut.context.ApplicationContext
+import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.websocket.WebSocketClient
+import io.micronaut.websocket.annotation.ClientWebSocket
+import io.micronaut.websocket.annotation.OnClose
+import io.micronaut.websocket.annotation.OnMessage
+import io.micronaut.websocket.annotation.OnOpen
+import io.reactivex.rxjava3.core.Flowable
+import org.reactivestreams.Publisher
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+import jakarta.inject.Inject
+import spock.lang.Stepwise
+import spock.util.concurrent.PollingConditions
+
+import java.util.concurrent.ConcurrentLinkedDeque
+
+@Stepwise
+@MicronautTest
+class ChatWebSocketSpec extends Specification {
+
+    @Inject ApplicationContext ctx
+
+    @Inject @Shared EmbeddedServer server
+
+    @AutoCleanup @Shared TestWebSocketClient client1
+    @AutoCleanup @Shared TestWebSocketClient client2
+    @AutoCleanup @Shared TestWebSocketClient client3
+
+    PollingConditions conditions = new PollingConditions(timeout: 5, initialDelay: 0.05, factor: 1.25)
+
+    void setupSpec() {
+        client1 = createWebSocketClient(server.port, 'topic_1', 'adam')
+        client2 = createWebSocketClient(server.port, 'topic_1', 'anna')
+        client3 = createWebSocketClient(server.port, 'topic_2', 'ben')
+    }
+
+    void 'should broadcast message when users connect to specific topic'() {
+        expect:
+        conditions.eventually {
+            assert client2.replies.asList() == ['[anna] Joined!']
+
+            assert client1.replies.asList() == ['[adam] Joined!', '[anna] Joined!']
+
+            assert client3.replies.asList() == ['[ben] Joined!']
+        }
+    }
+
+    void 'should broadcast message to all users inside the topic'() {
+        when:
+        client1.send 'Hello everyone!'
+
+        then:
+        conditions.eventually {
+            assert client1.replies.peekLast() == '[adam] Hello everyone!'
+
+            assert client2.replies.peekLast() == '[adam] Hello everyone!'
+
+            assert client3.replies.size() == 1
+        }
+
+        when:
+        client2.send 'Hi adam!'
+
+        then:
+        conditions.eventually {
+            assert client1.replies.peekLast() == '[anna] Hi adam!'
+
+            assert client2.replies.peekLast() == '[anna] Hi adam!'
+
+            assert client3.replies.size() == 1
+        }
+
+        when:
+        client3.send 'Is there anybody out there?'
+
+        then:
+        conditions.eventually {
+            assert client3.replies.size() == 2
+
+            assert client3.replies.peekLast() == '[ben] Is there anybody out there?'
+
+            assert client1.replies.peekLast() != '[ben] Is there anybody out there?'
+
+            assert client2.replies.peekLast() != '[ben] Is there anybody out there?'
+        }
+    }
+
+    void 'should broadcast message when user disconnects from the chat'() {
+        when:
+        client2.close()
+
+        then:
+        conditions.eventually {
+            assert client1.replies.peekLast() == '[anna] Disconnected!'
+        }
+    }
+
+    private TestWebSocketClient createWebSocketClient(int port, String topic, String username) {
+        WebSocketClient webSocketClient = ctx.getBean(WebSocketClient)
+
+        Publisher<TestWebSocketClient> client = webSocketClient.connect(TestWebSocketClient, "ws://localhost:${port}/ws/chat/${topic}/${username}")
+
+        return Flowable.fromPublisher(client).blockingFirst()
+    }
+
+    @CompileStatic
+    @ClientWebSocket
+    static abstract class TestWebSocketClient implements AutoCloseable {
+
+        final Collection<String> replies = new ConcurrentLinkedDeque<>()
+
+        @OnOpen
+        void onOpen() { }
+
+        @OnMessage
+        void onMessage(String message) {
+            replies.add(message)
+        }
+
+        @OnClose
+        void onClose() { }
+
+        abstract void send(String message)
+
+    }
+
+}


### PR DESCRIPTION
## Summary

This pull request upgrades the Micronaut version in the`websocket-chat` application to the latest version `3.1.3`. Changes in the `build.gradle` file were made using the default `build.gradle` file that is generated by the `mn` CLI for the latest version of the Micronaut framework

## Proposed changes:

* upgrade Micronaut version from `1.1.0` to `3.1.3`
* upgrade Gradle wrapper from `5.1.1` to `7.2`
* add Spock unit test